### PR TITLE
Fixed a bug where new notifications couldn't be displayed when the screen transitioned with the content left.

### DIFF
--- a/NavigationNotice/NavigationNotice.swift
+++ b/NavigationNotice/NavigationNotice.swift
@@ -304,6 +304,8 @@ open class NavigationNotice {
                 mainWindow = view.window
                 
                 notice.noticeViewController.showOn(view)
+            } else {
+                self.next()
             }
         }
         


### PR DESCRIPTION
## Reproduction procedure
- Create a button to display the notification.
- Tap the buttons continuously.
- Tap the navigation back button.
- Return to the screen that has the button again.
The notification cannot be displayed even if the button is tapped.

## Solution
If notice.noticeViewController.targetView is nil, call next().